### PR TITLE
Add inputs configuration option and set position on wrapper element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Configuration
 The path and the title of the different strength categories can
 be configured with the first parameter of `.strengthify`.
 
+The inputs property is an array of words to add to zxcvbn's dictionary
+or a function that returns the array to use.
+
 Default:
 
 ```JSON
@@ -52,7 +55,8 @@ Default:
     "So-so",
     "Good",
     "Perfect"
-  ]
+  ],
+  "inputs": []
 }
 ```
 

--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -41,7 +41,8 @@
 					'So-so',
 					'Good',
 					'Perfect'
-				]
+				],
+				inputs: []
 			},
 			options = $.extend(defaults, paramOptions);
 
@@ -60,10 +61,10 @@
 		}).done(function() {
 			me.bind('keyup input', function() {
 				var password = $(this).val(),
-					// hide strengthigy if no input is provided
+					// hide strengthify if no input is provided
 					opacity = (password === '') ? 0 : 1,
 					// calculate result
-					result = zxcvbn(password),
+					result = zxcvbn(password, typeof options.inputs === 'function' ? options.inputs() : options.inputs),
 					css = '',
 					// cache jQuery selections
 					$container = $('.strengthify-container'),

--- a/strengthify.css
+++ b/strengthify.css
@@ -6,6 +6,10 @@
  * Copyright (c) 2013 Morris Jobke <morris.jobke@gmail.com>
  */
 
+.strengthify-wrapper {
+	position: relative;
+}
+
 .strengthify-wrapper > * {
 	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
 	filter: alpha(opacity=0);


### PR DESCRIPTION
There was no option to set zxcvbn's second input argument which is an array of words (ex: the user's name or email from the same form) to the dictionary so they'll be penalized if used in the password.  Also found that the wrapper element needed `position:relative` to avoid its children breaking out across the page.