### PR TITLE
Replace tipsy with bootstrap's tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ password field.
 <div class="strengthify-wrapper"></div>
 ```
 
-Add `jquery` (tested with 1.10.0), `jquery.strengthify.js` and
+Add `jquery` (tested with 1.10.0), bootstrap's `tooltip.js`, `jquery.strengthify.js` and
 `strengthify.css` to your document.
 
 ```HTML
 <script src="jquery-1.10.0.min.js"></script>
-<script src="jquery-tipsy.js"></script>
+<script src="tooltip.js"></script>
 <script src="jquery.strengthify.js"></script>
 <link rel="stylesheet" href="strengthify.css" type="text/css">
 ```

--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -107,15 +107,15 @@
 				$wrapper.attr(
 					'title',
 					options.titles[result.score]
-				).tipsy({
+				).tooltip({
+					placement: 'bottom',
 					trigger: 'manual',
-					opacity: opacity
-				}).tipsy(
+				}).tooltip(
 					'show'
 				);
 
 				if(opacity === 0) {
-					$wrapper.tipsy(
+					$wrapper.tooltip(
 						'hide'
 					);
 				}


### PR DESCRIPTION
Besides replacing tipsy with tooltips, this PR removes the `opacity: opacity` setting, because it isn't supported by bootstrap and also wasn't needed in my opinion.