### PR TITLE
Use eval directly

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "strengthify",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "homepage": "https://github.com/MorrisJobke/strengthify",
   "authors": [
     "Eve Ragins <eve.ragins@eve-corp.com",

--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -199,9 +199,9 @@
 
                 $.ajax({
                     cache: true,
-                    dataType: 'script',
                     url: options.zxcvbn
-                }).done(function() {
+                }).done(function(content) {
+                    eval(content);
                     $elem.bind('keyup input change', drawSelf);
                 });
             };

--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -2,7 +2,7 @@
  * Strengthify - show the weakness of a password (uses zxcvbn for this)
  * https://github.com/MorrisJobke/strengthify
  *
- * Version: 0.5.1
+ * Version: 0.5.2
  * Author: Morris Jobke (github.com/MorrisJobke) - original
  *         Eve Ragins @ Eve Corp (github.com/eve-corp)
  *

--- a/strengthify.css
+++ b/strengthify.css
@@ -1,7 +1,7 @@
 /**
  * Strengthify - show the weakness of a password (uses zxcvbn for this)
  * https://github.com/MorrisJobke/strengthify
- * Version: 0.5.1
+ * Version: 0.5.2
  * License: The MIT License (MIT)
  * Copyright (c) 2013-2016 Morris Jobke <morris.jobke@gmail.com>
  */


### PR DESCRIPTION
We've overwritten jQuery.globalEval() for security reasons in Nextcloud, to make this now compatible again I've changed this code to manually call eval.

Ref https://github.com/nextcloud/server/issues/4067

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>
