### PR TITLE
Make possible to specify the element to add the strength bar after

### DIFF
--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -51,7 +51,8 @@
             },
             drawTitles: false,
             drawMessage: false,
-            drawBars: true
+            drawBars: true,
+            $addAfter: null
         };
 
         return this.each(function() {
@@ -175,8 +176,13 @@
                     elemId = $elem.attr('id');
                 var drawSelf = drawStrengthify.bind(this);
 
+                var $addAfter = options.$addAfter;
+                if (!$addAfter) {
+                    $addAfter = $elem;
+                }
+
                 // add elements
-                $elem.after('<div class="strengthify-wrapper" data-strengthifyFor="' + $elem.attr('id') + '"></div>');
+                $addAfter.after('<div class="strengthify-wrapper" data-strengthifyFor="' + $elem.attr('id') + '"></div>');
 
                 if (options.drawBars) {
                     getWrapperFor(elemId)


### PR DESCRIPTION
Before, the strength bar was always added after the element that `strengthify` was called on. Now it is possible to specify the element that the strength bar will be added after; if the `$addAfter` parameter
is not given then it is added after the element that `strengthify` was called on just like before.

**Pending:** update minified version. @rullzer What command did you use in #16?