### PR TITLE
Add userInputs option and pass to zxcvbn

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ be configured with the first parameter of `.strengthify`.
 
 
 <dl>
+<dt>userInputs</dt><dd> an array of strings that zxcvbn will treat as an extra dictionary</dd>
 <dt>drawTitles</dt><dd> pop-up text (above)</dd>
 <dt>drawMessage</dt><dd> detailed message beneath input</dd>
 <dt>drawBars</dt><dd> password strength color progression bars beneath input</dd>
@@ -58,6 +59,7 @@ Default:
 ```JSON
 {
   "zxcvbn": "zxcvbn/zxcvbn.js",
+  "userInputs": [],
   "titles": [
     "Weakest",
     "Weak",

--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -38,6 +38,7 @@
 
         var defaults = {
             zxcvbn: 'zxcvbn/zxcvbn.js',
+            userInputs: [],
             titles: [
                 'Weakest',
                 'Weak',
@@ -74,7 +75,7 @@
                     // hide strengthify if no input is provided
                     opacity = (password === '') ? 0 : 1,
                     // calculate result
-                    result = zxcvbn(password),
+                    result = zxcvbn(password, options.userInputs),
                     // setup some vars for later
                     css = '',
                     bsLevel = '',


### PR DESCRIPTION
zxcvbn accepts a list of strings that it will score as 1.
Because strengthify is calling zxcvbn, add a way to supply
the optional userInputs list to zxcvbn.