### PR TITLE
Add an option to disable the async zxcvbn.js loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ be configured with the first parameter of `.strengthify`.
 
 
 <dl>
+<dt>zxcvbn</dt><dd> path to xzcvbn.js, set to <code>null</code> to disable dynamic loading and assume zxcvbn.js is already loaded</dd>
 <dt>userInputs</dt><dd> an array of strings that zxcvbn will treat as an extra dictionary</dd>
 <dt>drawTitles</dt><dd> pop-up text (above)</dd>
 <dt>drawMessage</dt><dd> detailed message beneath input</dd>
@@ -86,7 +87,7 @@ $('#password-field').strengthify({
     zxcvbn: 'my/path/to/zxcvbn.js',
     onResult: function(result) {
         var submitBtn = $('input[type=submit]');
-      
+
         if (result.score < 3) {
           submitBtn.prop('disabled', 'disabled');
         } else {

--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -207,18 +207,25 @@
                     getWrapperFor(elemId).append('<div class="strengthify-tiles"></div>');
                 }
 
-                var script = document.createElement("script");
-                script.src = options.zxcvbn;
-                if (options.nonce !== null) {
-                    script.setAttribute('nonce', options.nonce);
-                }
+                if (options.zxcvbn) {
+                    // Load zxcvbn.js asynchronously
+                    var script = document.createElement("script");
+                    script.src = options.zxcvbn;
+                    if (options.nonce !== null) {
+                        script.setAttribute('nonce', options.nonce);
+                    }
 
-                script.onload = function() {
-                	$elem.parent().on('scroll', drawSelf);
+                    script.onload = function() {
+                    	$elem.parent().on('scroll', drawSelf);
                         $elem.bind('keyup input change', drawSelf);
-                }
+                    }
 
-                document.head.appendChild(script);
+                    document.head.appendChild(script);
+                } else {
+                    // Assume zxcvbn.js is already loaded
+                    $elem.parent().on('scroll', drawSelf);
+                    $elem.bind('keyup input change', drawSelf);
+                }
             };
 
             init.call(this);


### PR DESCRIPTION
Proposal: allow user to pass a `zxcvbn:null` option:

    $('#password-field').strengthify({zxcvbn: null})

In this case, assume zxcvbn.js is already loaded in the page and is ready to use.

Motivation: in my use case, zxcvbn.js is already included in the JS bundle sent to the browser. It does not make sense to load it again.